### PR TITLE
Change type variable from const to let

### DIFF
--- a/drawingtokenizer.js
+++ b/drawingtokenizer.js
@@ -175,7 +175,7 @@
 			content: form,
 			yes: html => {
 				const filename = html.find("input")[0].value;
-				const type = html.find("select")[0].value;
+				let type = html.find("select")[0].value;
 				let quality = html.find("input")[1].value;
 				try {
 					quality = parseFloat(quality);


### PR DESCRIPTION
Hi,

Thank you for this module!

I'm using Firefox and had issues with converting drawings to image. I did a bit of digging and found that when WebP support isn't detected the type variable is forced to PNG, but since type is a const the reassignment throws an error instead and breaks the module on Firefox. So this is just a quick pull request changing type to a let instead.

Cheers!