### PR TITLE
Update to FoundryVTT API v11 and v12

### DIFF
--- a/drawingtokenizer.js
+++ b/drawingtokenizer.js
@@ -63,12 +63,15 @@
 		 */
 		static getContainerBlob(container, type, quality) {
 			return new Promise(function(resolve, reject) {
-				console.log(canvas.app.renderer.extract.image(container, type, quality).src);
-				fetch(canvas.app.renderer.extract.image(container, type, quality).src)
-				.then(res => res.blob())
-				.then(blob => {
-					resolve(blob);
-				});
+				(async () => {
+					let img = await canvas.app.renderer.extract.image(container, type, quality);
+					console.log(img.src);
+					fetch(img.src)
+					.then(res => res.blob())
+					.then(blob => {
+						resolve(blob);
+					});
+				})()
 			})
 		  }
 
@@ -114,16 +117,14 @@
 			const source="data";
 			let target=DrawingTokenizer.getWorldPath();
 
-			let data = {action: "browseFiles", storage: source, target: target};
-			let files = await FilePicker._manageFiles(data, options);
+			let files = await FilePicker.browse(source, target, options);
 			let DirExists=false;
 			target=DrawingTokenizer.getUploadPath();
 			files.dirs.forEach(dir => {
 				DirExists= DirExists || dir===target;
 			});
 			if(!DirExists){
-				data = {action: "createDirectory", storage: source, target: target};
-				await FilePicker._manageFiles(data, options);
+				await FilePicker.createDirectory(source, target, options);
 			}
 		}
 		

--- a/module.json
+++ b/module.json
@@ -4,9 +4,9 @@
 	"description": "Allows to convert one or multiple drawings into a image.",
 	"version": "2.1.2",
 	"compatibility" :{
-		"minimum": 10,	
-		"verified": "10.286",
-		"maximum": 10	
+		"minimum": 11,
+		"verified": "12.331",
+		"maximum": 12
 	},
 	"authors": [
 		{


### PR DESCRIPTION
This pull request changes how DrawingTokenizer uses the FilePicker object, also awaits on the result from canvas.app.renderer.extract.image. The former change is required because the _manageFiles method was deprecated in FilePicker. Instead, the browse and createDirectory methods were used. The latter change to how canvas.app.renderer.extract.image() is called is required because this function is async in v11+... so the previous way of calling it always returned `undefined`.

I have verified that this PR works in FoundryVTT v11.315 and v12.331.